### PR TITLE
Add call to sys.exit() with non-zero exit code on Exception

### DIFF
--- a/openquake/hme/bin/hamlet.py
+++ b/openquake/hme/bin/hamlet.py
@@ -68,6 +68,9 @@ def main(arg=None):
 
         if args.pdb:
             debugger.post_mortem()
+        else:
+            # Exit with non-zero error code so that tests fail
+            sys.exit(1)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Add call to sys.exit() with non-zero exit code so that tests using hamlet (e.g. internal mosaic tests) can detect failure.  
At present hamlet always exits with exit-code 0, so tests think all is well even when hamlet encounters an error